### PR TITLE
downgrading elasticsearch client. the latest version throwing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 urllib3~=1.26.7
-elasticsearch~=7.15.1
+elasticsearch<7.14.0
 requests~=2.26.0
 kubernetes~=18.20.0
 retry~=0.9.2


### PR DESCRIPTION
elasticsearch.exceptions.UnsupportedProductError: The client noticed that the server is not a supported distribution of Elasticsearch