### PR TITLE
Fix kibana env indentation

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -74,10 +74,10 @@ objects:
           - containerPort: 5601
           env:
             - name: ELASTICSEARCH_HOSTS
-                valueFrom:
-                  secretKeyRef:
-                    key: endpoint
-                    name: assisted-installer-elasticsearch
+              valueFrom:
+                secretKeyRef:
+                  key: endpoint
+                  name: assisted-installer-elasticsearch
             - name: ELASTICSEARCH_USERNAME
               value: ""
             - name: ELASTICSEARCH_PASSWORD


### PR DESCRIPTION
This was causing a failure to deploy the template:

```
error fetching template: mapping values are not allowed here
  in "<byte string>", line 77, column 26:
                    valueFrom:
```