### PR TITLE
Limiting access to Kibana to users with access to the kibana-proxy se…

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -140,6 +140,7 @@ objects:
           - --upstream=http://localhost:5601
           - --https-address=
           - --pass-basic-auth=false
+          - --openshift-sar='{"namespace":"${NAMESPACE}","resource":"services","name":"kibana-proxy","verb":"get"}'
           env:
           - name: OAUTH2_PROXY_COOKIE_SECRET
             valueFrom:


### PR DESCRIPTION
…rvice in the current namespace

It was required by the App-SRE team to limit access to Kibana to Assisted-Installer users only (not all users with access to Openshift).