### PR TITLE
Removing invalid quote

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -140,7 +140,7 @@ objects:
           - --upstream=http://localhost:5601
           - --https-address=
           - --pass-basic-auth=false
-          - --openshift-sar='{"namespace":"${NAMESPACE}","resource":"services","name":"kibana-proxy","verb":"get"}'
+          - --openshift-sar={"namespace":"${NAMESPACE}","resource":"services","name":"kibana-proxy","verb":"get"}
           env:
           - name: OAUTH2_PROXY_COOKIE_SECRET
             valueFrom:


### PR DESCRIPTION
Section starts with "--" shouldn't have an escaping
Cause: "unable to decode review: invalid character '\'' looking for beginning of value"