### PR TITLE
Adding NAMESPACE param definition to the template

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -165,4 +165,6 @@ parameters:
   value: quay.io/openshift/origin-oauth-proxy
 - name: OAUTH_IMAGE_TAG
   value: 4.4.0
+- name: NAMESPACE
+  value: ''
 


### PR DESCRIPTION
The NAMESPACE param used for Kibana oauth2 proxy
only users with access to the namespace kibana-proxy service can access the Kibana instance