### PR TITLE
An empty inventory field caused events-scrape to fail

### DIFF
--- a/assisted-events-scrape/events_scrape/process.py
+++ b/assisted-events-scrape/events_scrape/process.py
@@ -40,7 +40,7 @@ class GetProcessedMetadataJson:
 
     def __set_host_vendor(self):
         for host in self.metadata_json["cluster"]["hosts"]:
-            if "inventory" not in host:
+            if "inventory" not in host or host["inventory"] is None:
                 return
             inventory = json.loads(host["inventory"])
             vendor = inventory.get("system_vendor", None)


### PR DESCRIPTION
When a host registers a cluster, the inventory is empty until the inventory command is executed.
We should handle an empty inventory case even though the inventory step should be performed immediately after host discovery