### PR TITLE
Proxy AWS opendistro dashboard directly

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,11 @@
+# Deployment
+
+The `assisted-events-scrape` project is composed by two main deployables: `assisted-events-scraper` and `kibana-proxy`.
+
+### assisted-events-scraper
+
+CLI application that runs standalone.
+
+### kibana-proxy
+
+Kibana is exposed through a OAUTH proxy, which authenticates users. Once users are authenticated, Elasticsearch's AWS OpenDistro Dashboard is proxied to the user, where another login is necessary for authorization.

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -105,28 +105,6 @@ objects:
       spec:
         serviceAccountName: kibana-proxy
         containers:
-        - name: kibana
-          image: ${KIBANA_IMAGE}:${KIBANA_TAG}
-          ports:
-          - containerPort: 5601
-          env:
-            - name: ELASTICSEARCH_HOSTS
-              valueFrom:
-                secretKeyRef:
-                  key: endpoint
-                  name: assisted-installer-elasticsearch
-            - name: ELASTICSEARCH_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  key: master_user_name
-                  name: elastic-master-credentials
-            - name: ELASTICSEARCH_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  key: master_user_password
-                  name: elastic-master-credentials
-            - name: ELASTICSEARCH_SSL_VERIFICATIONMODE
-              value: none
         - name: kibana-proxy
           image: ${OAUTH_IMAGE}:${OAUTH_IMAGE_TAG}
           imagePullPolicy: IfNotPresent
@@ -154,7 +132,7 @@ objects:
           - --http-address=0.0.0.0:3000
           - --provider=openshift
           - --openshift-service-account=kibana-proxy
-          - --upstream=http://localhost:5601
+          - --upstream=$(KIBANA_ENDPOINT)
           - --https-address=
           - --pass-basic-auth=false
           - --openshift-sar={"namespace":"$(NAMESPACE)","resource":"services","name":"kibana-proxy","verb":"get"}
@@ -163,6 +141,11 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: KIBANA_ENDPOINT
+            valueFrom:
+              secretKeyRef:
+                key: kibana_endpoint
+                name: assisted-installer-elasticsearch
           - name: OAUTH2_PROXY_COOKIE_SECRET
             valueFrom:
               secretKeyRef:
@@ -178,10 +161,6 @@ parameters:
   value: "1"
 - name: ES_INDEX
   value: ''
-- name: KIBANA_IMAGE
-  value: quay.io/app-sre/kibana-oss
-- name: KIBANA_TAG
-  value: 7.10.2
 - name: OAUTH_IMAGE
   value: quay.io/openshift/origin-oauth-proxy
 - name: OAUTH_IMAGE_TAG


### PR DESCRIPTION
Current situation:
* we are using AWS elasticsearch service
* we are deploying our own in-cluster kibana instance, connected with AWS elasticsearch endpoint
* in front of kibana we use OAuth proxy for authorization

This change aims to simplify the architecture of the app by removing an unnecessary component: in-cluster kibana.
Instead of it, we will directly forward AWS's kibana console through OAuth proxy.