### PR TITLE
add sentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ This tool can be used by `events_scrape` cli command (if installed) or running u
 | `OFFLINE_TOKEN`       | Assisted service offline token  | |
 | `BACKUP_DESTINATION`  | Path to save backup, if empty no backups will be saved  | |
 | `SSO_URL`             | SSO server URL  | |
-
+| `SENTRY_DSN`          | Sentry DSN | |

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -34,6 +34,8 @@ objects:
             - secretRef:
                 name: events-scrape
           env:
+          - name: SENTRY_DSN
+            value: ${SENTRY_DSN}
           - name: ES_SERVER
             valueFrom:
               secretKeyRef:
@@ -165,3 +167,5 @@ parameters:
   value: quay.io/openshift/origin-oauth-proxy
 - name: OAUTH_IMAGE_TAG
   value: 4.4.0
+- name: SENTRY_DSN
+  value: ''

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ kubernetes~=18.20.0
 retry~=0.9.2
 waiting~=1.4.1
 assisted-service-client>=1.0.27.1
+sentry-sdk~=1.5
 flake8
 pylint
 wheel


### PR DESCRIPTION
The purpose of this PR is to add sentry.io to this project.

The logic is that if env var `SENTRY_DSN` is not defined, the application will behave as it did before this change.

If it is set, we will register all exceptions, so that we can make sure all issues are addressed.
Errors will be found at this dashboard https://sentry.stage.devshift.net/sentry/assisted-events-scrape-stage/

This has been tested in integration, by swapping values that would be set in stage.

@michaellevy101  it appears that there is no sentry team defined for integration - is this done on purpose? Or shall we activate integration sentry too?