### PR TITLE
improve error handling and data collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,15 @@ This tool can be used by `events_scrape` cli command (if installed) or running u
 ### Environment variables
 | Variable    |  Description   | Example    |
 | --- | --- | --- |
-| `ES_INDEX`            | Elasticsearch index name | assisted-service-events |
-| `ES_SERVER`           | Elasticsearch server address |  |
-| `LOGS_DEST`(optional) | Logs path, can be relative, default to the stdout | assisted-events-scrape.log |
-| `ES_USER`(optional)   | Elasticsearch user name | elastic |
-| `ES_PASS`(optional)   | Elasticsearch password  |  |
-| `ASSISTED_SERVICE_URL`| Assisted service url  | https://api.openshift.com |
-| `OFFLINE_TOKEN`       | Assisted service offline token  | |
-| `BACKUP_DESTINATION`  | Path to save backup, if empty no backups will be saved  | |
-| `SSO_URL`             | SSO server URL  | |
-| `SENTRY_DSN`          | Sentry DSN | |
+| `ES_INDEX`              | Elasticsearch index name | assisted-service-events |
+| `ES_SERVER`             | Elasticsearch server address |  |
+| `LOGS_DEST`(optional)   | Logs path, can be relative, default to the stdout | assisted-events-scrape.log |
+| `ES_USER`(optional)     | Elasticsearch user name | elastic |
+| `ES_PASS`(optional)     | Elasticsearch password  |  |
+| `ASSISTED_SERVICE_URL`  | Assisted service url  | https://api.openshift.com |
+| `OFFLINE_TOKEN`         | Assisted service offline token  | |
+| `BACKUP_DESTINATION`    | Path to save backup, if empty no backups will be saved  | |
+| `SSO_URL`               | SSO server URL  | |
+| `SENTRY_DSN`            | Sentry DSN | |
+| `ERRORS_BEFORE_RESTART` | Maximum numbner of errors allowed before restarting the application | |
+| `MAX_IDLE_MINUTES`      | Minutes allowed for the application to be idle. Idle time is when the application is not being updated, either succesfully or unsuccesfully | |

--- a/assisted-events-scrape/events_scrape/events_scrape.py
+++ b/assisted-events-scrape/events_scrape/events_scrape.py
@@ -2,6 +2,7 @@
 
 import re
 import os
+import sys
 import time
 import json
 import random
@@ -11,6 +12,9 @@ import hashlib
 import tempfile
 import elasticsearch
 import sentry_sdk
+from datetime import datetime
+from datetime import timedelta
+
 from sentry_sdk import capture_exception
 
 from assisted_service_client import rest
@@ -22,6 +26,8 @@ from .logger import log
 
 RETRY_INTERVAL = 60 * 5
 MAX_EVENTS = 5000
+DEFAULT_ENV_ERRORS_BEFORE_RESTART = "100"
+DEFAULT_ENV_MAX_IDLE_MINUTES = "120"
 
 UUID_REGEX = r'[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}'
 
@@ -33,8 +39,10 @@ es_logger.setLevel(logging.WARNING)
 
 class ScrapeEvents:
     def __init__(self, inventory_url: str, offline_token: str, index: str, es_server: str, es_user: str,
-                 es_pass: str, backup_destination: str):
+                 es_pass: str, backup_destination: str, is_sentry_enabled: bool, max_idle_minutes: int,
+                 errors_before_restart: int):
 
+        self.latest_update = datetime.now()
         self.inventory_url = inventory_url
         self.client = ClientFactory.create_client(url=self.inventory_url, offline_token=offline_token)
         self.index = index
@@ -49,6 +57,24 @@ class ScrapeEvents:
             os.makedirs(self.backup_destination)
 
         self.cache_event_count_per_cluster = dict()
+        self.is_sentry_enabled = is_sentry_enabled
+        self.max_idle_minutes = max_idle_minutes
+        self.errors_before_restart = errors_before_restart
+        self.error_count = 0
+
+    def is_idle(self):
+        if self.max_idle_minutes < 0:
+            return False
+        return datetime.now() > (self.latest_update + timedelta(minutes=self.max_idle_minutes))
+
+    def has_too_many_unexpected_errors(self):
+        return self.error_count > self.errors_before_restart
+
+    def handle_unexpected_error(self, e: Exception, msg: str):
+        self.error_count += 1
+        if self.is_sentry_enabled:
+            capture_exception(e)
+        log.exception(msg)
 
     def run_service(self):
 
@@ -65,21 +91,28 @@ class ScrapeEvents:
             for i, cluster in enumerate(clusters):
                 cluster_id = cluster["id"]
                 log.info(f"{i}/{cluster_count}: Starting process of cluster {cluster_id}")
-                if "hosts" not in cluster or len(cluster["hosts"]) == 0:
-                    try:
-                        cluster["hosts"] = self.client.get_cluster_hosts(cluster_id=cluster["id"])
-                    except rest.ApiException as e:
-                        if e.reason == "Not Found":
-                            log.info(f"Failed to fetch cluster({cluster_id}) events, "
-                                     "probably a deleted cluster - skipping ", exc_info=True)
-                            continue
-                        else:
-                            raise
-
-                self.process_cluster(cluster)
+                try:
+                    cluster["hosts"] = self.fetch_hosts(cluster)
+                    if len(cluster["hosts"]) > 0:
+                        self.process_cluster(cluster)
+                except Exception as e:
+                    self.handle_unexpected_error(e, f'Error while processing cluster {cluster_id}')
 
             log.info("Finish syncing all clusters - sleeping 30 seconds")
             time.sleep(30)
+
+    def fetch_hosts(self, cluster):
+        cluster_id = cluster["id"]
+        hosts = []
+        if "hosts" not in cluster or len(cluster["hosts"]) == 0:
+            try:
+                hosts = self.client.get_cluster_hosts(cluster_id=cluster_id)
+            except rest.ApiException as e:
+                if e.reason != "Not Found":
+                    raise
+                log.info(f"Failed to fetch cluster({cluster_id}) events, "
+                         "probably a deleted cluster - skipping ", exc_info=True)
+        return hosts
 
     def get_metadata_json(self, cluster: dict):
         d = {'cluster': cluster}
@@ -93,6 +126,7 @@ class ScrapeEvents:
                 event_list = json.load(f)
 
         self.elastefy_events(cluster, event_list)
+        self.latest_update = datetime.now()
 
     def elastefy_events(self, cluster, event_list):
         cluster_id = cluster["id"]
@@ -241,7 +275,9 @@ def handle_arguments():
         "es_pass": get_env("ES_PASS"),
         "index": get_env("ES_INDEX", mandatory=True),
         "backup_destination": get_env("BACKUP_DESTINATION"),
-        "sentry_dsn": get_env("SENTRY_DSN", default="")
+        "sentry_dsn": get_env("SENTRY_DSN", default=""),
+        "max_idle_minutes": get_env("MAX_IDLE_MINUTES", default=DEFAULT_ENV_MAX_IDLE_MINUTES),
+        "errors_before_restart": get_env("ERRORS_BEFORE_RESTART", default=DEFAULT_ENV_ERRORS_BEFORE_RESTART)
     }
 
 
@@ -256,21 +292,26 @@ def initSentry(sentry_dsn):
 
 def main():
     args = handle_arguments()
-    sentry_enabled = initSentry(args["sentry_dsn"])
+    is_sentry_enabled = initSentry(args["sentry_dsn"])
+    should_run = True
+    while should_run:
+        scrape_events = ScrapeEvents(inventory_url=args["assisted_service_url"],
+                                     offline_token=args["offline_token"],
+                                     index=args["index"],
+                                     es_server=args["es_server"],
+                                     es_user=args["es_user"],
+                                     es_pass=args["es_pass"],
+                                     backup_destination=args["backup_destination"],
+                                     is_sentry_enabled=is_sentry_enabled,
+                                     max_idle_minutes=int(args["max_idle_minutes"]),
+                                     errors_before_restart=int(args["errors_before_restart"]))
 
-    while True:
-        try:
-            scrape_events = ScrapeEvents(inventory_url=args["assisted_service_url"],
-                                         offline_token=args["offline_token"],
-                                         index=args["index"],
-                                         es_server=args["es_server"],
-                                         es_user=args["es_user"],
-                                         es_pass=args["es_pass"],
-                                         backup_destination=args["backup_destination"])
-            scrape_events.run_service()
-        except Exception as e:
-            if sentry_enabled:
-                capture_exception(e)
-            log.warning(f'Elastefying events failed with error, sleeping for {RETRY_INTERVAL} and retrying',
-                        exc_info=True)
-            time.sleep(RETRY_INTERVAL)
+        scrape_events.run_service()
+        if scrape_events.is_idle():
+            log.Error("Scraping is idle, exiting...")
+            should_run = False
+        if scrape_events.has_too_many_unexpected_errors():
+            log.Error("Too many unexpected errors, exiting")
+            should_run = False
+
+    sys.exit(1)

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -36,6 +36,10 @@ objects:
           env:
           - name: SENTRY_DSN
             value: ${SENTRY_DSN}
+          - name: MAX_IDLE_MINUTES
+            value: ${MAX_IDLE_MINUTES}
+          - name: ERRORS_BEFORE_RESTART
+            value: ${ERRORS_BEFORE_RESTART}
           - name: ES_SERVER
             valueFrom:
               secretKeyRef:
@@ -168,4 +172,8 @@ parameters:
 - name: OAUTH_IMAGE_TAG
   value: 4.4.0
 - name: SENTRY_DSN
+  value: ''
+- name: MAX_IDLE_MINUTES
+  value: ''
+- name: ERRORS_BEFORE_RESTART
   value: ''


### PR DESCRIPTION
The aim of this PR is to try reduce inconsistencies we have between elastic data and sql production data.

At the moment we are missing lots of events:
* looping through cluster should take several minutes
* however, sometimes it never happens. if we throw an exception it might raise to the first loop, and restart the process from step 1 (retrieving all clusters). This means that if we get to another exception, we restart. Some unlucky clusters can take days to show up its events
* particularly problematic the case of quick registration and deregistration of clusters. As we do not retrieve unregistered clusters, we'll never receive any events for this case
* another scenario is when a cluster is deregistered, as we are not currently listing all clusters, we'll miss all events from deregistration on

Solutions/patches:

* we list all clusters, even unregistered ones.
* we capture any exception when processing clusters and log a warning.


With the proposed solution we should minimize problems listed above, and reduce lag (possibly to a couple of hours in worst case scenario, for now)


NOTE: We'll integrate sentry in this exception catching, either on sentry's PR (https://github.com/openshift-assisted/assisted-events-scrape/pull/46) or this one, depending which gets merged first.