### PR TITLE
add default values for env var, as empty string breaks the code

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -174,6 +174,6 @@ parameters:
 - name: SENTRY_DSN
   value: ''
 - name: MAX_IDLE_MINUTES
-  value: ''
+  value: '120'
 - name: ERRORS_BEFORE_RESTART
-  value: ''
+  value: '100'


### PR DESCRIPTION
This is fixed in https://github.com/openshift-assisted/assisted-events-scrape/pull/49 (from both code and default value for env vars).

This PR is needed to fix deployments in the meantime the other PR will get merged