### PR TITLE
MGMT-9468: add json logging for better parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ This tool can be used by `events_scrape` cli command (if installed) or running u
 | --- | --- | --- |
 | `ES_INDEX`              | Elasticsearch index name | assisted-service-events |
 | `ES_SERVER`             | Elasticsearch server address |  |
-| `LOGS_DEST`(optional)   | Logs path, can be relative, default to the stdout | assisted-events-scrape.log |
 | `ES_USER`(optional)     | Elasticsearch user name | elastic |
 | `ES_PASS`(optional)     | Elasticsearch password  |  |
 | `ASSISTED_SERVICE_URL`  | Assisted service url  | https://api.openshift.com |

--- a/assisted-events-scrape/events_scrape/events_scrape.py
+++ b/assisted-events-scrape/events_scrape/events_scrape.py
@@ -162,7 +162,7 @@ class ScrapeEvents:
             self.cache_event_count_per_cluster[cluster_id] = cluster_events_count_from_db
         if cluster_events_count_from_db < relevant_event_count:
             missing_events = relevant_event_count - cluster_events_count_from_db
-            logging.info(f"cluster {cluster_id} is missing {missing_events} events")
+            log.info(f"cluster {cluster_id} is missing {missing_events} events")
             return True
         else:
             return False

--- a/assisted-events-scrape/events_scrape/logger.py
+++ b/assisted-events-scrape/events_scrape/logger.py
@@ -1,59 +1,31 @@
 # -*- coding: utf-8 -*-
 import logging
-import os
-import re
 import sys
+from pythonjsonlogger import jsonlogger
 
 
-class SensitiveFormatter(logging.Formatter):
-    """Formatter that removes sensitive info."""
-
-    @staticmethod
-    def _filter(s):
-        # Dict filter
-        s = re.sub(r"('_pull_secret':\s+)'(.*?)'", r"\g<1>'*** PULL_SECRET ***'", s)
-        s = re.sub(r"('_ssh_public_key':\s+)'(.*?)'", r"\g<1>'*** SSH_KEY ***'", s)
-        s = re.sub(r"('_vsphere_username':\s+)'(.*?)'", r"\g<1>'*** VSPHERE_USER ***'", s)
-        s = re.sub(r"('_vsphere_password':\s+)'(.*?)'", r"\g<1>'*** VSPHERE_PASSWORD ***'", s)
-
-        # Object filter
-        s = re.sub(r"(pull_secret='[^']*(?=')')", "pull_secret = *** PULL_SECRET ***", s)
-        s = re.sub(r"(ssh_public_key='[^']*(?=')')", "ssh_public_key = *** SSH_KEY ***", s)
-        s = re.sub(r"(vsphere_username='[^']*(?=')')", "vsphere_username = *** VSPHERE_USER ***", s)
-        s = re.sub(r"(vsphere_password='[^']*(?=')')", "vsphere_password = *** VSPHERE_PASSWORD ***", s)
-
-        return s
-
-    def format(self, record):
-        original = logging.Formatter.format(self, record)
-        return self._filter(original)
+def get_custom_format() -> str:
+    log_fields = [
+        "asctime",
+        "name",
+        "levelname",
+        "thread",
+        "message",
+        "pathname",
+        "lineno",
+    ]
+    return " ".join([f"%({field})s" for field in log_fields])
 
 
 logging.getLogger("requests").setLevel(logging.ERROR)
 logging.getLogger("urllib3").setLevel(logging.ERROR)
 
-log = logging.getLogger("")
+log = logging.getLogger()
 log.setLevel(logging.DEBUG)
-fmt = SensitiveFormatter("%(asctime)s - %(name)s - %(levelname)s - %(thread)d - %(message)s")
+
+fmt = jsonlogger.JsonFormatter(get_custom_format())
 
 ch = logging.StreamHandler(sys.stdout)
-ch.setFormatter(
-    SensitiveFormatter(
-        "%(asctime)s %(levelname)-10s - %(thread)d - %(message)s \t" "(%(pathname)s:%(lineno)d)"
-    )
-)
+ch.setFormatter(fmt)
 
 log.addHandler(ch)
-
-
-def add_log_file_handler(filename: str) -> logging.FileHandler:
-    fh = logging.FileHandler(filename)
-    fh.setFormatter(fmt)
-    log.addHandler(fh)
-    return fh
-
-
-log_file = os.environ.get("LOGS_DEST")
-
-if log_file is not None:
-    add_log_file_handler(log_file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ retry~=0.9.2
 waiting~=1.4.1
 assisted-service-client>=1.0.27.1
 sentry-sdk~=1.5
+python-json-logger~=2.0
 flake8
 pylint
 wheel


### PR DESCRIPTION
This PR aims to improve parseability of logs by switching to JSON logging.

This way we will be able to better parse logs, faster filters, and better information in the grafana dashboards

from:
```
2022-03-17 08:57:26,390 INFO       - 140295224396672 - 217/410: Starting process of cluster 896396a3-fd0d-41a1-b9a8-bacfc1464b05 	(/usr/local/lib/python3.6/site-packages/events_scrape/events_scrape.py:93)
2022-03-17 08:57:26,418 INFO       - 140295224396672 - 218/410: Starting process of cluster 5241b682-0557-48b1-9687-a4282ff0a337 	(/usr/local/lib/python3.6/site-packages/events_scrape/events_scrape.py:93)
2022-03-17 08:57:26,458 INFO       - 140295224396672 - Downloading cluster events to /tmp/tmpz6g3y73b 	(/usr/local/lib/python3.6/site-packages/events_scrape/assisted_service_api.py:381)
```

to:
```
{"asctime": "2022-03-17 10:48:03,870", "name": "root", "levelname": "INFO", "thread": 139765136161664, "message": "2/5: Starting process of cluster 6bf691d4-eeca-4483-a9a9-487c0bb7aa26", "pathname": "/usr/local/lib/python3.6/site-packages/events_scrape/events_scrape.py", "lineno": 93}
{"asctime": "2022-03-17 10:48:03,883", "name": "root", "levelname": "INFO", "thread": 139765136161664, "message": "3/5: Starting process of cluster b16b416b-fdd2-4942-b795-7bc0534a062d", "pathname": "/usr/local/lib/python3.6/site-packages/events_scrape/events_scrape.py", "lineno": 93}
{"asctime": "2022-03-17 10:48:03,893", "name": "root", "levelname": "INFO", "thread": 139765136161664, "message": "4/5: Starting process of cluster 5a2f9e8a-9d4e-44fc-b0ae-c2ad66d4b200", "pathname": "/usr/local/lib/python3.6/site-packages/events_scrape/events_scrape.py", "lineno": 93}
{"asctime": "2022-03-17 10:48:03,921", "name": "root", "levelname": "INFO", "thread": 139765136161664, "message": "Downloading cluster events to /tmp/tmpp768r326", "pathname": "/usr/local/lib/python3.6/site-packages/events_scrape/assisted_service_api.py", "lineno": 381}
```

tested in integration