### PR TITLE
change owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,28 +2,10 @@
 
 aliases:
   code-reviewers:
-    - michaellevy101
-    - avishayt
-    - empovit
-    - eranco74
-    - ori-amizur
-    - tsorya
-    - yevgeny-shnaidman
-    - masayag
-    - carbonin
-    - rollandf
-    - danielerez
-    - ybettan
-    - slaviered
-    - asalkeld
   code-approvers:
+    - adriengentil
+    - rccrdpccl
     - michaellevy101
-    - mkowalski
-    - romfreiman
-    - celebdor
-    - filanov
     - gamli75
     - osherdp
-    - oshercc
-    - omertuc
     - eliorerz


### PR DESCRIPTION
Update with people that are actually working on the project: we avoid spamming on other teammates mail and get relevant people on the review.