### PR TITLE
remove unused code

### DIFF
--- a/assisted-events-scrape/config/scraper_config.py
+++ b/assisted-events-scrape/config/scraper_config.py
@@ -36,7 +36,6 @@ class ElasticsearchConfig:
 @dataclass
 class ScraperConfig:
     inventory_url: str
-    backup_destination: str
     offline_token: str
     sentry: SentryConfig
     elasticsearch: ElasticsearchConfig
@@ -49,7 +48,6 @@ class ScraperConfig:
         n_workers = max(MINIMUM_WORKERS, int(get_env("N_WORKERS", default=DEFAULT_ENV_N_WORKERS)))
         return ScraperConfig(
             get_env("ASSISTED_SERVICE_URL"),
-            get_env("BACKUP_DESTINATION"),
             get_env("OFFLINE_TOKEN", mandatory=True),
             SentryConfig.create_from_env(),
             ElasticsearchConfig.create_from_env(),

--- a/assisted-events-scrape/events_scrape/events_scrape.py
+++ b/assisted-events-scrape/events_scrape/events_scrape.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import os
 import sys
 import time
 import logging
@@ -25,9 +24,6 @@ es_logger.setLevel(logging.WARNING)
 
 class ScrapeEvents:
     def __init__(self, config: ScraperConfig):
-        if config.backup_destination and not os.path.exists(config.backup_destination):
-            os.makedirs(config.backup_destination)
-
         self._client = ClientFactory.create_client(url=config.inventory_url, offline_token=config.offline_token)
         self._cluster_events_storage = ClusterEventsStorage.create_with_inventory_client(self._client, config)
 

--- a/assisted-events-scrape/repositories/event_repository.py
+++ b/assisted-events-scrape/repositories/event_repository.py
@@ -1,8 +1,4 @@
-import json
-import tempfile
-
-from contextlib import suppress
-from assisted_service_client import rest
+EVENT_CATEGORIES = ["user", "metrics"]
 
 
 class EventRepository:
@@ -10,12 +6,4 @@ class EventRepository:
         self._client = assisted_client
 
     def get_cluster_events(self, cluster_id: str) -> list:
-        with tempfile.NamedTemporaryFile() as temp_event_file:
-            self.write_events_file(cluster_id, temp_event_file.name)
-            with open(temp_event_file.name) as f:
-                event_list = json.load(f)
-        return event_list
-
-    def write_events_file(self, cluster_id, output_file):
-        with suppress(rest.ApiException):
-            self._client.download_cluster_events(cluster_id, output_file, categories=["user", "metrics"])
+        return self._client.get_events(cluster_id, categories=EVENT_CATEGORIES)


### PR DESCRIPTION
Remove unused code:
* "backups" are done in ephemeral disks, and have never been used. Not sure how we'd be supposed to use them anyways
* Removed unnecessary disk operations when retrieving events