### PR TITLE
increase number of errors before restart default value

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -181,6 +181,6 @@ parameters:
 - name: MAX_IDLE_MINUTES
   value: '120'
 - name: ERRORS_BEFORE_RESTART
-  value: '100'
+  value: '10000'
 - name: N_WORKERS
   value: '5'


### PR DESCRIPTION
100 is a very low value, a small bug that would be caught anyway and will prevent to loop through all clusters, making this feature harmful.
Let's try with 10000