### PR TITLE
fix CI integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ unit-test:
 
 ci-integration-test:
 	./tools/deploy_manifests.sh ocp $(ASSISTED_EVENTS_SCRAPE_IMAGE) $(TEST_NAMESPACE)
-	ES_SERVER=$(./tools/get_ocp_route_host.sh) ES_INDEX=assisted-service-events pytest assisted-events-scrape/tests/integration
+	ES_SERVER=$$(./tools/get_ocp_route_host.sh):80 ES_INDEX=assisted-service-events pytest assisted-events-scrape/tests/integration
 
 integration-test: build-image
 	kind get clusters | grep assisted-events-scrape || kind create cluster --name assisted-events-scrape

--- a/tools/deploy_manifests.sh
+++ b/tools/deploy_manifests.sh
@@ -18,7 +18,7 @@ ${cli} get ns ${namespace} || ${cli} create ns ${namespace}
 ${cli} apply ${ns} -f assisted-events-scrape/tests/integration/manifests
 
 if [[ "${platform}" == "ocp" ]]; then
-    ${cli} process --local=true -f assisted-events-scrape/tests/integration/ci-manifests/ --output=yaml --param ELASTICSEARCH_ROUTE_HOST=$(./tools/get_ocp_route_host.sh) | ${cli} apply -f -
+    ${cli} process --local=true -f assisted-events-scrape/tests/integration/ci-manifests/ --output=yaml --param ELASTICSEARCH_ROUTE_HOST=$(./tools/get_ocp_route_host.sh) | ${cli} apply ${ns} -f -
 fi
 
 
@@ -27,7 +27,9 @@ ${cli} wait ${ns} --timeout=300s --for=condition=Ready pods --all
 
 # Deploy assisted-events-scraper
 if [[ "${platform}" == "ocp" ]]; then
-    ${cli} apply ${ns} -f openshift/
+    image_name=$(echo $ASSISTED_EVENTS_SCRAPE_IMAGE | cut -d: -f1)
+    image_tag=$(echo $ASSISTED_EVENTS_SCRAPE_IMAGE | cut -d: -f2)
+    ${cli} process --output=yaml ${ns} -f openshift/template.yaml --param IMAGE_NAME=${image_name} IMAGE_TAG=${image_tag} | ${cli} apply ${ns} -f -
 else
     ./tools/ocp2k8s.sh ${image} | ${cli} apply ${ns} -f -
 fi

--- a/tools/get_ocp_route_host.sh
+++ b/tools/get_ocp_route_host.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -eu
 
 cluster_domain=$(cat $KUBECONFIG | grep server | awk '{ print $2 }' | cut -d. -f2- | cut -d: -f1)
-echo "elasticsearch-assisted.${OPENSHIFT_BUILD_NAMESPACE}.${cluster_domain}"
+echo "elasticsearch-assisted-${OPENSHIFT_BUILD_NAMESPACE}.apps.${cluster_domain}"


### PR DESCRIPTION
The aim of this PR is to fix a few details about integration testing in CI.
Once merged, when `make ci-integration-test` is run from CI should successfully run integration tests.