### PR TITLE
rebuild elasticdump image

### DIFF
--- a/Dockerfile.elasticdump
+++ b/Dockerfile.elasticdump
@@ -1,0 +1,9 @@
+FROM registry.access.redhat.com/ubi8/nodejs-14-minimal:1-43
+
+ENV ES_DUMP_VER=v6.82.3
+ENV NODE_ENV production
+ENV PATH $PATH:${NPM_CONFIG_PREFIX}/bin
+
+RUN npm install elasticdump@${ES_DUMP_VER} -g
+
+ENTRYPOINT ["elasticdump"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 CONTAINER_COMMAND := $(shell ./tools/utils.sh get_container_runtime_command)
 TAG := $(or ${TAG},latest)
+ELASTICDUMP_TAG := $(or ${ELASTICDUMP_TAG}, v6.82.3)
 ASSISTED_EVENTS_SCRAPE_IMAGE := $(or $(ASSISTED_EVENTS_SCRAPE_IMAGE),quay.io/edge-infrastructure/assisted-events-scrape:$(TAG))
+ELASTICDUMP_IMAGE := $(or $(ELASTICDUMP_IMAGE),quay.io/app-sre/elasticdump:$(ELASTICDUMP_TAG))
 TEST_NAMESPACE := assisted-events-scrape-test
 
 install_assisted_service_client:
@@ -8,6 +10,9 @@ install_assisted_service_client:
 
 build-image:
 	$(CONTAINER_COMMAND) build $(CONTAINER_BUILD_EXTRA_PARAMS) -t $(ASSISTED_EVENTS_SCRAPE_IMAGE) .
+
+build-elasticdump-image:
+	$(CONTAINER_COMMAND) build $(CONTAINER_BUILD_EXTRA_PARAMS) -t $(ELASTICDUMP_IMAGE) . -f Dockerfile.elasticdump
 
 build-wheel:
 	rm -rf ./dist ./build

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -6,11 +6,10 @@ TAG=$(git rev-parse --short=7 HEAD)
 REPO="quay.io/app-sre/assisted-events-scrape"
 export ASSISTED_EVENTS_SCRAPE_IMAGE="${REPO}:${TAG}"
 export CONTAINER_BUILD_EXTRA_PARAMS="--no-cache"
-make build-image
+export ELASTICDUMP_IMAGE="quay.io/app-sre/elasticdump:v6.82.3"
 
-export ELASTICDUMP_IMAGE_REPO="quay.io/app-sre/elasticdump"
-export ELASTICDUMP_IMAGE_TAG="v6.82.3"
-export ELASTICDUMP_ORIGINAL_REPO="elasticdump/elasticsearch-dump"
+make build-image
+make build-elasticdump-image
 
 DOCKER_CONF="$PWD/assisted/.docker"
 mkdir -p "$DOCKER_CONF"
@@ -18,6 +17,4 @@ docker --config="$DOCKER_CONF" login -u="${QUAY_USER}" -p="${QUAY_TOKEN}" quay.i
 docker tag "${ASSISTED_EVENTS_SCRAPE_IMAGE}" "${REPO}:latest"
 docker --config="$DOCKER_CONF" push "${ASSISTED_EVENTS_SCRAPE_IMAGE}"
 docker --config="$DOCKER_CONF" push "${REPO}:latest"
-docker pull "${ELASTICDUMP_ORIGINAL_REPO}:${ELASTICDUMP_IMAGE_TAG}"
-docker tag "${ELASTICDUMP_ORIGINAL_REPO}:${ELASTICDUMP_IMAGE_TAG}" "${ELASTICDUMP_IMAGE_REPO}:${ELASTICDUMP_IMAGE_TAG}"
-docker --config="$DOCKER_CONF" push "${ELASTICDUMP_IMAGE_REPO}:${ELASTICDUMP_IMAGE_TAG}"
+docker --config="$DOCKER_CONF" push "${ELASTICDUMP_IMAGE}"


### PR DESCRIPTION
According to App-SRE is best practice to avoid docker.io mirroring.
Instead, it is recommended to rebuild this image from a trusted source.