### PR TITLE
use default build_root image

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,3 +1,4 @@
 build_root_image:
-  project_image:
-    dockerfile_path: Dockerfile.build
+  name: release
+  namespace: openshift
+  tag: rhel-8-release-golang-1.17-openshift-4.11


### PR DESCRIPTION
This uses valid syntax for build root. Leaving a default image here, but in the future it can be change within the repo instead of having to open a `release` PR