### PR TITLE
use centos as build_root image

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,0 @@
-build_root_image:
-  name: release
-  namespace: openshift
-  tag: rhel-8-release-golang-1.17-openshift-4.11


### PR DESCRIPTION
Remove CI operator config, now unnecessary