### PR TITLE
ignore cluster fields in checksum, to avoid frequent status changes

### DIFF
--- a/assisted-events-scrape/config/event_store.py
+++ b/assisted-events-scrape/config/event_store.py
@@ -1,3 +1,4 @@
+from typing import List
 from dataclasses import dataclass
 from utils import get_env
 
@@ -15,10 +16,18 @@ class EventStoreConfig:
     events_index: str
     cluster_events_index: str
     component_versions_events_index: str
+    cluster_events_ignore_fields: List[str]
 
     @classmethod
     def create_from_env(cls) -> 'EventStoreConfig':
+        cluster_events_ignore_fields = []
+        cluster_events_ignore_fields_str = get_env("EVENT_STORE_CLUSTER_EVENTS_IGNORE_FIELDS", default="")
+        if len(cluster_events_ignore_fields_str) > 0:
+            cluster_events_ignore_fields = cluster_events_ignore_fields_str.split(",")
+
         return cls(
             get_env("EVENT_STORE_EVENTS_IDX", default=DEFAULT_EVENTS_IDX),
             get_env("EVENT_STORE_CLUSTER_EVENTS_IDX", default=DEFAULT_CLUSTER_EVENTS_IDX),
-            get_env("EVENT_STORE_COMPONENT_VERSIONS_EVENTS_IDX", default=DEFAULT_COMPONENT_VERSIONS_EVENTS_IDX))
+            get_env("EVENT_STORE_COMPONENT_VERSIONS_EVENTS_IDX", default=DEFAULT_COMPONENT_VERSIONS_EVENTS_IDX),
+            cluster_events_ignore_fields
+        )

--- a/assisted-events-scrape/storage/object_storage_writer.py
+++ b/assisted-events-scrape/storage/object_storage_writer.py
@@ -2,6 +2,7 @@ from typing import Iterable
 import json
 import boto3
 import smart_open
+import dpath.util
 from utils import log
 from config import ObjectStorageConfig
 from .offset import DateOffsetOptions, DateOffset
@@ -62,18 +63,14 @@ class ObjectStorageWriter:
 
     # pylint: disable=no-self-use
     def _get_partition_from_doc(self, doc: dict, partition_key: str) -> str:
-        return _get_dotkey_value(doc, partition_key)
+        try:
+            return dpath.util.get(doc, partition_key, separator=".")
+        except KeyError:
+            return None
 
     def _get_offset_from_doc(self, doc: dict, order_key: str) -> str:
-        return _get_dotkey_value(doc, order_key)
-    # pylint: enable=no-self-use
-
-
-def _get_dotkey_value(doc: dict, dotkey: str) -> str:
-    key_parts = dotkey.split(".")
-    d = doc
-    for key in key_parts:
-        if key not in d:
+        try:
+            return dpath.util.get(doc, order_key, separator=".")
+        except KeyError:
             return None
-        d = d[key]
-    return d
+    # pylint: enable=no-self-use

--- a/assisted-events-scrape/tests/integration/test_elasticsearch_storage.py
+++ b/assisted-events-scrape/tests/integration/test_elasticsearch_storage.py
@@ -67,7 +67,7 @@ class TestElasticsearchStorage:
 
         assert len(all_docs["hits"]["hits"]) == 1
 
-    def test_store_changes_with_enrich_document_fn(self):
+    def test_store_changes_with_transform_document_fn(self):
         def add_qux(x: dict) -> dict:
             x["qux"] = "foobar"
             return x
@@ -79,7 +79,7 @@ class TestElasticsearchStorage:
             index=self._index,
             documents=docs,
             id_fn=get_doc_checksum,
-            enrich_document_fn=add_qux
+            transform_document_fn=add_qux
         )
 
         # make sure the value is visible in the index
@@ -91,7 +91,7 @@ class TestElasticsearchStorage:
         assert "qux" in all_docs["hits"]["hits"][0]["_source"]
         assert all_docs["hits"]["hits"][0]["_source"]["qux"] == "foobar"
 
-        # still won't add a new document if we try without enrich document fn
+        # still won't add a new document if we try without transform document fn
         self._es_store.store_changes(
             index=self._index,
             documents=docs,

--- a/assisted-events-scrape/tests/unit/test_cluster_events_worker.py
+++ b/assisted-events-scrape/tests/unit/test_cluster_events_worker.py
@@ -171,9 +171,9 @@ class TestClusterEventsWorker:
     def _expect_store_normalized_events(self):
         expected_calls = [
             call(index=self.config.events.component_versions_events_index,
-                 documents=ANY, id_fn=get_dict_hash, enrich_document_fn=ANY),
+                 documents=ANY, id_fn=get_dict_hash, transform_document_fn=ANY),
             call(index=self.config.events.cluster_events_index, filter_by=ANY,
-                 documents=ANY, id_fn=get_dict_hash),
+                 documents=ANY, id_fn=ANY),
             call(index=self.config.events.events_index, documents=ANY, filter_by=ANY,
                  id_fn=get_event_id),
         ]

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -34,6 +34,8 @@ objects:
             - secretRef:
                 name: events-scrape
           env:
+          - name: EVENT_STORE_CLUSTER_EVENTS_IGNORE_FIELDS
+            value: "hosts.*.connectivity,hosts.*.progress"
           - name: SENTRY_DSN
             value: "${SENTRY_DSN}"
           - name: SENTRY_RELEASE

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ dataclasses~=0.8
 wheel
 smart-open[s3]~=5.2.1
 boto3~=1.22.6
+dpath~=2.0.6


### PR DESCRIPTION
the aim of this PR is to remove some fields from cluster metadata when determining the checksum. This will help us reducing the number of cluster events due to unnecessary fields