### PR TITLE
add hosts.inventory to ignored fields

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -35,7 +35,7 @@ objects:
                 name: events-scrape
           env:
           - name: EVENT_STORE_CLUSTER_EVENTS_IGNORE_FIELDS
-            value: "hosts.*.connectivity,hosts.*.progress,hosts.*.checked_in_at,hosts.*.updated_at"
+            value: "hosts.*.connectivity,hosts.*.inventory,hosts.*.progress,hosts.*.checked_in_at,hosts.*.updated_at"
           - name: SENTRY_DSN
             value: "${SENTRY_DSN}"
           - name: SENTRY_RELEASE


### PR DESCRIPTION
We'll ignore inventory when calculating if the cluster changed.
We will store it nevertheless (just when something else change, we'll store the current inventory)