### PR TITLE
add default protocol

### DIFF
--- a/assisted-events-scrape/config/object_storage.py
+++ b/assisted-events-scrape/config/object_storage.py
@@ -2,6 +2,9 @@ from dataclasses import dataclass
 from utils import get_env
 
 
+DEFAULT_S3_ENDPOINT_PROTOCOL = "s3://"
+
+
 @dataclass
 class ObjectStorageConfig:
     access_key: str
@@ -11,6 +14,9 @@ class ObjectStorageConfig:
 
     @classmethod
     def create_from_env(cls) -> 'ObjectStorageConfig':
+        endpoint = get_env("AWS_S3_BUCKET")
+        if "://" not in endpoint:
+            endpoint = DEFAULT_S3_ENDPOINT_PROTOCOL + endpoint
         return cls(
             get_env("AWS_ACCESS_KEY_ID"),
             get_env("AWS_SECRET_ACCESS_KEY"),


### PR DESCRIPTION
Cronjob fails without protocol.
Minio needs http, this should be good with `s3://`