### PR TITLE
order hosts when calculating checksum

### DIFF
--- a/assisted-events-scrape/workers/cluster_events_worker.py
+++ b/assisted-events-scrape/workers/cluster_events_worker.py
@@ -137,7 +137,13 @@ class ClusterEventsWorker:
             except PathNotFound:
                 # if field is not there, no need to delete it, but don't fail
                 pass
+        if "hosts" in doc_copy:
+            doc_copy["hosts"].sort(key=by_id)
         return get_dict_hash(doc_copy)
+
+
+def by_id(item: dict) -> str:
+    return item.get("id", None)
 
 
 def add_timestamp(doc: dict) -> dict:


### PR DESCRIPTION
This avoids calculating different hash when only the order is different