### PR TITLE
add more fields to ignore

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -258,7 +258,7 @@ parameters:
 - name: EVENT_EXPORT_STREAM_CHUNK_SIZE
   value: "1000"
 - name: EVENT_STORE_CLUSTER_EVENTS_IGNORE_FIELDS
-  value: "hosts.*.connectivity,hosts.*.inventory,hosts.*.progress,hosts.*.checked_in_at,hosts.*.updated_at,controller_logs_collected_at,controller_logs_started_at,updated_at"
+  value: "hosts.*.connectivity,hosts.*.inventory,hosts.*.progress,hosts.*.checked_in_at,hosts.*.updated_at,hosts.*.validations_info,hosts.*.ntp_sources,controller_logs_collected_at,controller_logs_started_at,updated_at,connectivity_majority_groups"
 - name: MEMORY_LIMIT
   value: "1000Mi"
   required: false


### PR DESCRIPTION
Lets filter more fields and see if we can get rid of a couple of cases where host keeps updating ntp sources causing thousands of events