### PR TITLE
bugfix: do not modify cluster event object

### DIFF
--- a/assisted-events-scrape/tests/integration/test_integration.py
+++ b/assisted-events-scrape/tests/integration/test_integration.py
@@ -49,6 +49,21 @@ class TestIntegration:
             except TimeoutExpired:
                 # Wait function expired, it means doc count could not match in the given time
                 assert False
+        query = {
+            "size": 1,
+            "query": {
+                "term": {
+                    "cluster.id": {
+                        "value": "d386f7df-03ba-46bf-a49b-f6b65a0fb90d"
+                    }
+                }
+            }
+        }
+        response = self._es_client.search(index=self._config.index, body=query)
+        doc = response["hits"]["hits"][0]["_source"]
+        assert "infra_env" in doc["cluster"]
+        assert doc["cluster"]["infra_env"]["org_id"] == "xxxxxxxx"
+        assert doc["cluster"]["infra_env"]["type"] == "full-iso"
 
     def test_s3_upload(self):
         endpoint_url = os.getenv("AWS_S3_ENDPOINT")

--- a/assisted-events-scrape/workers/cluster_events_worker.py
+++ b/assisted-events-scrape/workers/cluster_events_worker.py
@@ -126,9 +126,10 @@ class ClusterEventsWorker:
                     "cluster_id": cluster["id"]
                 }
             }
-            infra_env = cluster.get("infra_env")
+            cluster_copy = deepcopy(cluster)
+            infra_env = cluster_copy.get("infra_env")
             if infra_env:
-                del cluster["infra_env"]
+                del cluster_copy["infra_env"]
                 self._es_store.store_changes(
                     index=EventStoreConfig.INFRA_ENVS_EVENTS_INDEX,
                     documents=[infra_env],
@@ -143,7 +144,7 @@ class ClusterEventsWorker:
             )
             self._es_store.store_changes(
                 index=EventStoreConfig.CLUSTER_EVENTS_INDEX,
-                documents=[cluster],
+                documents=[cluster_copy],
                 id_fn=self._cluster_checksum,
                 filter_by=cluster_id_filter)
             self._es_store.store_changes(


### PR DESCRIPTION
When saving enriched event we want to have `infra_env` as a property of cluster object, however when saving normalized events, we do not want it.
The code was mistakenly modifying the original object, thus not saving infra_env values in the events.