### PR TITLE
MGMT-10912 - Remove `user_name` from cluster object

### DIFF
--- a/assisted-events-scrape/storage/cluster_events_storage.py
+++ b/assisted-events-scrape/storage/cluster_events_storage.py
@@ -6,6 +6,8 @@ from clients import create_es_client_from_env
 from config import ScraperConfig
 from events_scrape import InventoryClient
 import opensearchpy
+import fnv
+
 from . import process
 
 MAX_EVENTS = 5000
@@ -36,6 +38,7 @@ class ClusterEventsStorage:
 
         metadata_json = get_metadata_json(cluster, component_versions)
 
+        self._hash_user_name(metadata_json["cluster"])
         cluster_bash_data = process_metadata(metadata_json)
         event_names = get_cluster_object_names(cluster_bash_data)
 
@@ -46,6 +49,21 @@ class ClusterEventsStorage:
             log.info(f"Cluster {cluster_id} logged events are not same as the event count, logging all clusters events")
             events = self.process_events(cluster_bash_data, event_list, event_names)
             self.store_events(events, only_new_events=False)
+
+    @classmethod
+    def _hash_user_name(cls, cluster: dict):
+        """mask user name with unique generated FNV-1a 128 bit id"""
+        if "user_name" not in cluster:
+            return
+
+        user_name = cluster.get("user_name")
+        del cluster["user_name"]
+
+        # empty username
+        if not user_name:
+            cluster["user_id"] = None
+        else:
+            cluster["user_id"] = str(fnv.hash(str(user_name).encode(), algorithm=fnv.fnv_1a, bits=128))
 
     def process_events(self, cluster_bash_data, event_list, event_names):
         for event in event_list[::-1]:

--- a/assisted-events-scrape/tests/integration/test_integration.py
+++ b/assisted-events-scrape/tests/integration/test_integration.py
@@ -65,6 +65,9 @@ class TestIntegration:
         assert doc["cluster"]["infra_env"]["org_id"] == "xxxxxxxx"
         assert doc["cluster"]["infra_env"]["type"] == "full-iso"
 
+        assert "user_name" not in doc["cluster"]
+        assert "user_id" in doc["cluster"]
+
     def test_s3_upload(self):
         endpoint_url = os.getenv("AWS_S3_ENDPOINT")
         session = boto3.Session(

--- a/elasticsearch/templates/assisted-service-events.json
+++ b/elasticsearch/templates/assisted-service-events.json
@@ -45,6 +45,13 @@
             "type" : "keyword"
           }
         }
+      },
+      "cluster": {
+        "properties": {
+          "user_id": {
+            "type": "keyword"
+          }
+        }
       }
     }
   },

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ wheel
 smart-open[s3]~=5.2.1
 boto3~=1.22.6
 dpath~=2.0.6
+fnv~=0.2.0


### PR DESCRIPTION
- Remove user_name from cluster object (elastic)
- Set unique user_id using FNV-1a 128bit algorithm instead (not reversible)

/cc @rccrdpccl 