### PR TITLE
remove UUID5 conversion, as it generates collisions

### DIFF
--- a/assisted-events-scrape/tests/integration/test_integration.py
+++ b/assisted-events-scrape/tests/integration/test_integration.py
@@ -7,7 +7,6 @@ import re
 import json
 import random
 from typing import List
-from uuid import UUID
 from config import EventStoreConfig
 from waiting import TimeoutExpired
 from utils import log
@@ -86,7 +85,6 @@ class TestIntegration:
         assert "user_name" not in doc["cluster"]
         assert "user_id" in doc["cluster"]
         assert "cluster_state_id" in doc["cluster"]
-        assert is_valid_uuid(doc["cluster"]["cluster_state_id"])
 
     def test_s3_uploaded_files(self):
         objects = self._s3_client.list_objects(Bucket=self._s3_bucket_name)
@@ -109,7 +107,6 @@ class TestIntegration:
         assert "user_name" not in random_cluster
         assert "user_id" in random_cluster
         assert "cluster_state_id" in random_cluster
-        assert is_valid_uuid(random_cluster["cluster_state_id"])
 
     @classmethod
     def _get_s3_client(cls):
@@ -161,11 +158,3 @@ def at_least_one_matches_key(objects: List[dict], key: str, match: str) -> bool:
         if re.search(match, obj[key]):
             return True
     return False
-
-
-def is_valid_uuid(uuid: str) -> bool:
-    try:
-        validated_uuid = UUID(uuid)
-    except ValueError:
-        return False
-    return uuid == str(validated_uuid)

--- a/assisted-events-scrape/workers/cluster_events_worker.py
+++ b/assisted-events-scrape/workers/cluster_events_worker.py
@@ -4,7 +4,6 @@ from copy import deepcopy
 import queue
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
-from uuid import UUID, uuid5
 import dpath.util
 from dpath.exceptions import PathNotFound
 from retry import retry
@@ -16,8 +15,6 @@ from config import SentryConfig, EventStoreConfig
 from assisted_service_client.rest import ApiException
 
 EVENT_CATEGORIES = ["user", "metrics"]
-# Namespace needed for creation of UUID5
-CLUSTER_STATE_ID_NAMESPACE = UUID('f2f6efbc-613f-4747-8873-27fc1a39231e')
 
 
 @dataclass
@@ -177,7 +174,7 @@ class ClusterEventsWorker:
         return get_dict_hash(doc_copy)
 
     def _enrich_cluster(self, doc: dict):
-        doc["cluster_state_id"] = str(uuid5(CLUSTER_STATE_ID_NAMESPACE, self._cluster_checksum(doc)))
+        doc["cluster_state_id"] = self._cluster_checksum(doc)
 
 
 def by_id(item: dict) -> str:


### PR DESCRIPTION
After all it was not such a great idea to standardize this field, as UUID5 generates way too many collisions for this.
Let's stick to the original checksum