### PR TITLE
enable cron suspend

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -158,6 +158,7 @@ objects:
   metadata:
     name: ccx-export
   spec:
+    suspend: ${{CCX_EXPORT_CRON_SUSPEND}}
     schedule: "${CCX_EXPORT_CRON_TIME}"
     jobTemplate:
       spec:
@@ -267,3 +268,5 @@ parameters:
   value: master_user_password
 - name: CCX_EXPORT_CRON_TIME
   value: "0 2 * * *"
+- name: CCX_EXPORT_CRON_SUSPEND
+  value: "false"


### PR DESCRIPTION
Enable the ability to suspend cronjob from parameters.
This is useful if we want to temporarely suspend it without deploying a new version of the application (just changing params)
