### PR TITLE
reduce flakiness of integration test: wait for minio jobs

### DIFF
--- a/tools/deploy_manifests.sh
+++ b/tools/deploy_manifests.sh
@@ -26,6 +26,7 @@ ${cli} wait ${ns} --timeout=300s --for=condition=Available deployment --all
 ${cli} wait ${ns} --timeout=300s --for=condition=Ready pods -l app=elasticsearch-master
 ${cli} wait ${ns} --timeout=300s --for=condition=Ready pods -l app=mockserver
 ${cli} wait ${ns} --timeout=300s --for=condition=Ready pods -l app=minio
+${cli} wait ${ns} --timeout=120s --for=condition=complete job ai-events-minio-make-bucket-job ai-events-minio-make-user-job
 
 # Write elasticsearch index templates
 if [[ "${platform}" == "ocp" ]]; then


### PR DESCRIPTION
Sometimes the jobs start too fast, before minio server, and they fail. They would eventually succeed, but we run tests before they have a chance to run again. Let's wait for them a couple of minutes, so we avoid failing a test that potentially would pass.