### PR TITLE
explicitly call GC

### DIFF
--- a/assisted-events-scrape/storage/object_storage_writer.py
+++ b/assisted-events-scrape/storage/object_storage_writer.py
@@ -1,4 +1,5 @@
 from typing import Iterable, Callable
+import gc
 import json
 import boto3
 import smart_open
@@ -66,8 +67,8 @@ class ObjectStorageWriter:
             log.debug(f"Writing document: {document}")
             document_str = json.dumps(document)
             streams[key].write(document_str + "\n")
-            del document
-            del document_str
+
+            gc.collect()
 
         for stream in streams.values():
             stream.close()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18526422/186401309-3182089a-5515-42ef-b0a4-7a90f5ea2081.png)

First two runs (purple and red lines) are with `del <object>` but not calling explicitly Garbage Collector, third run calls explicitly GC (yellow line).

![image](https://user-images.githubusercontent.com/18526422/186403880-7a43e91f-9270-4cf2-a0c1-a20931f92e85.png)
The first run (bright yellow) in the chart above is explicit GC call with explicit call for `del <object>` , while the second (darker yellow) is explicit GC call without explicit `del <object>` call


This improves memory used and should help running the job with massive amount of data, although the job will run slower.
