### PR TITLE
add event_id to event payload for export

### DIFF
--- a/assisted-events-scrape/tests/integration/test_integration.py
+++ b/assisted-events-scrape/tests/integration/test_integration.py
@@ -124,6 +124,18 @@ class TestIntegration:
         assert "user_id" in random_cluster
         assert "cluster_state_id" in random_cluster
 
+    def test_s3_exported_events_object(self):
+        events_export = get_first_object_matching_key(
+            client=self._s3_client,
+            bucket=self._s3_bucket_name,
+            match=".*events.*")
+        events = [json.loads(line) for line in events_export["Body"].readlines()]
+
+        random_event = random.choice(events)
+        assert "event_time" in random_event
+        assert "cluster_id" in random_event
+        assert "event_id" in random_event
+
     @classmethod
     def _get_s3_client(cls):
         endpoint_url = os.getenv("AWS_S3_ENDPOINT")

--- a/assisted-events-scrape/tests/unit/test_cluster_events_worker.py
+++ b/assisted-events-scrape/tests/unit/test_cluster_events_worker.py
@@ -284,7 +284,7 @@ class TestClusterEventsWorker:
             call(index=self.config.events.cluster_events_index, filter_by=ANY,
                  documents=ANY, id_fn=ANY),
             call(index=self.config.events.events_index, documents=ANY, filter_by=ANY,
-                 id_fn=get_event_id),
+                 id_fn=get_event_id, transform_document_fn=ANY),
             call(index=self.config.events.component_versions_events_index,
                  documents=ANY, id_fn=ANY, transform_document_fn=ANY),
         ]

--- a/assisted-events-scrape/workers/cluster_events_worker.py
+++ b/assisted-events-scrape/workers/cluster_events_worker.py
@@ -156,6 +156,7 @@ class ClusterEventsWorker:
                 index=EventStoreConfig.EVENTS_INDEX,
                 documents=event_list,
                 id_fn=get_event_id,
+                transform_document_fn=add_event_id,
                 filter_by=cluster_id_filter
             )
             self._es_store.store_changes(
@@ -208,6 +209,12 @@ def add_timestamp(doc: dict) -> dict:
     # produces it with `Z` notation. To be consistent, we get UTC time
     # without tz info, and append 'Z' in the end
     d["timestamp"] = datetime.utcnow().isoformat() + "Z"
+    return d
+
+
+def add_event_id(doc: dict) -> dict:
+    d = deepcopy(doc)
+    d["event_id"] = get_event_id(doc)
     return d
 
 


### PR DESCRIPTION
This exports event_id. useful to identify (and ignore) duplicates in other systems (i.e. CCX)