### PR TITLE
use suffixed indices for easier maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This tool can be used by `events_scrape` cli command (if installed) or running u
 ### Environment variables
 | Variable    |  Description   | Example    |
 | --- | --- | --- |
-| `ES_INDEX`              | Elasticsearch index name | assisted-service-events |
+| `ES_INDEX_PREFIX`       | Elasticsearch index prefix, will be suffixed by YYYY-MM | assisted-service-events-v3- |
 | `ES_SERVER`             | Elasticsearch server address |  |
 | `ES_USER`(optional)     | Elasticsearch user name | elastic |
 | `ES_PASS`(optional)     | Elasticsearch password  |  |

--- a/assisted-events-scrape/config/elasticsearch.py
+++ b/assisted-events-scrape/config/elasticsearch.py
@@ -5,7 +5,7 @@ from utils import get_env
 @dataclass
 class ElasticsearchConfig:
     host: str
-    index: str
+    index_prefix: str
     username: str
     password: str
 
@@ -13,6 +13,6 @@ class ElasticsearchConfig:
     def create_from_env(cls) -> 'ElasticsearchConfig':
         return cls(
             get_env("ES_SERVER"),
-            get_env("ES_INDEX"),
+            get_env("ES_INDEX_PREFIX"),
             get_env("ES_USER"),
             get_env("ES_PASS"))

--- a/elasticsearch/templates/assisted-service-events.json
+++ b/elasticsearch/templates/assisted-service-events.json
@@ -1,8 +1,7 @@
 {
   "order" : 0,
   "index_patterns" : [
-    "assisted-service-events*",
-    "restored_assisted-service-events*"
+    "assisted-service-events-v3-*"
   ],
   "settings" : {
     "index" : {
@@ -11,6 +10,19 @@
       "mapping" : {
         "total_fields" : {
           "limit" : "10000"
+        }
+      }
+    },
+    "analysis": {
+      "analyzer": {
+        "comma_separated": {
+          "tokenizer": "comma_separated"
+        }
+      },
+      "tokenizer": {
+        "comma_separated": {
+          "type": "pattern",
+          "pattern": ","
         }
       }
     }
@@ -50,10 +62,22 @@
         "properties": {
           "user_id": {
             "type": "keyword"
+          },
+          "tags": {
+            "type": "text",
+            "analyzer": "comma_separated",
+            "fields": {
+              "keyword": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
           }
         }
       }
     }
   },
-  "aliases" : { }
+  "aliases" : {
+    "assisted-service-events": {}
+  }
 }

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -53,8 +53,8 @@ objects:
               secretKeyRef:
                 key: endpoint
                 name: assisted-installer-elasticsearch
-          - name: ES_INDEX
-            value: "${ES_INDEX}"
+          - name: ES_INDEX_PREFIX
+            value: "${ES_INDEX_PREFIX}"
           - name: ES_USER
             valueFrom:
               secretKeyRef:
@@ -282,8 +282,8 @@ parameters:
   required: true
 - name: REPLICAS_COUNT
   value: "1"
-- name: ES_INDEX
-  value: 'assisted-service-events'
+- name: ES_INDEX_PREFIX
+  value: 'assisted-service-events-v3-'
 - name: OAUTH_IMAGE
   value: quay.io/openshift/origin-oauth-proxy
 - name: OAUTH_IMAGE_TAG

--- a/tools/run_integration_test.sh
+++ b/tools/run_integration_test.sh
@@ -12,7 +12,7 @@ else
     export AWS_S3_ENDPOINT=http://$(./tools/get_endpoint.sh ${namespace} ai-events-minio)
 fi
 
-export ES_INDEX=assisted-service-events
+export ES_INDEX_PREFIX=assisted-service-events-v3-
 export AWS_SECRET_ACCESS_KEY=$(oc -n ${namespace} get secret ai-ccx-integration -o jsonpath='{.data.aws_secret_access_key}' | base64 --decode)
 export AWS_ACCESS_KEY_ID=$(oc -n ${namespace} get secret ai-ccx-integration -o jsonpath='{.data.aws_access_key_id}' | base64 --decode)
 export AWS_S3_BUCKET=$(oc -n ${namespace} get secret ai-ccx-integration -o jsonpath='{.data.bucket}' | base64 --decode)


### PR DESCRIPTION
This PR aims at simplifying maintenance and increase performance:
* when a mistake in mapping makes it to the target environment, we need lengthy and sometimes complicated operations to fix it. If the mistake it's limited to the latest month, there is way less data to deal with making everything simpler. This is true not only for mistakes but for backups, migrations, etc... we could enable straight away latest months while restoring older dates, and most people would not be affected by this
* increase performance when searching in the last few months. It will be a bit more expensive for queries that include several months, as results will need to be merged
