### PR TITLE
date depends on data instead of time of indexing

### DIFF
--- a/assisted-events-scrape/storage/cluster_events_storage.py
+++ b/assisted-events-scrape/storage/cluster_events_storage.py
@@ -1,7 +1,7 @@
 import re
 import time
 import json
-from datetime import datetime
+from dateutil.parser import parse as parse_date
 from utils import log, get_event_id
 from clients import create_es_client_from_env
 from config import ScraperConfig
@@ -102,7 +102,7 @@ class ClusterEventsStorage:
 
     def log_doc(self, doc, id_):
         try:
-            index = self._index_prefix + datetime.today().strftime("%Y-%m")
+            index = self._index_prefix + parse_date(doc["event_time"]).strftime("%Y-%m")
             res = self._es_client.create(index=index, body=doc, id=id_)
         except opensearchpy.exceptions.ConflictError:
             log.debug("Hit logged event")

--- a/assisted-events-scrape/tests/integration/fixtures/events-fc124c08-f3a5-464f-834e-c262d9eb5a38.json
+++ b/assisted-events-scrape/tests/integration/fixtures/events-fc124c08-f3a5-464f-834e-c262d9eb5a38.json
@@ -1,5 +1,5 @@
 [
-  {"cluster_id":"fc124c08-f3a5-464f-834e-c262d9eb5a38","event_time":"2022-03-08T12:46:43.453Z","message":"Successfully registered cluster","name":"cluster_registration_succeeded","severity":"info"},
-  {"cluster_id":"fc124c08-f3a5-464f-834e-c262d9eb5a38","event_time":"2022-03-08T12:46:49.469Z","message":"Updated status of the cluster to pending-for-input","name":"cluster_status_updated","severity":"info"},
-  {"cluster_id":"fc124c08-f3a5-464f-834e-c262d9eb5a38","event_time":"2022-03-08T12:59:40.257Z","host_id":"35b7346e-b486-46e0-b553-6e6355eb5a17","infra_env_id":"39b315e3-f9d4-4869-8927-a6d56c26c5ac","message":"Host 35b7346e-b486-46e0-b553-6e6355eb5a17: Successfully registered","name":"host_registration_succeeded","severity":"info"}
+  {"cluster_id":"fc124c08-f3a5-464f-834e-c262d9eb5a38","event_time":"2022-04-08T12:46:43.453Z","message":"Successfully registered cluster","name":"cluster_registration_succeeded","severity":"info"},
+  {"cluster_id":"fc124c08-f3a5-464f-834e-c262d9eb5a38","event_time":"2022-04-08T12:46:49.469Z","message":"Updated status of the cluster to pending-for-input","name":"cluster_status_updated","severity":"info"},
+  {"cluster_id":"fc124c08-f3a5-464f-834e-c262d9eb5a38","event_time":"2022-04-08T12:59:40.257Z","host_id":"35b7346e-b486-46e0-b553-6e6355eb5a17","infra_env_id":"39b315e3-f9d4-4869-8927-a6d56c26c5ac","message":"Host 35b7346e-b486-46e0-b553-6e6355eb5a17: Successfully registered","name":"host_registration_succeeded","severity":"info"}
 ]

--- a/assisted-events-scrape/tests/integration/test_integration.py
+++ b/assisted-events-scrape/tests/integration/test_integration.py
@@ -114,11 +114,13 @@ class TestIntegration:
         return doc["_source"]
 
     def test_s3_uploaded_files(self):
+        expected_s3_objects_count = 6
         objects = self._s3_client.list_objects(Bucket=self._s3_bucket_name)
         # it should have one upload each event type
-        assert len(objects['Contents']) == 5
+        assert len(objects['Contents']) == expected_s3_objects_count
         assert at_least_one_matches_key(objects['Contents'], "Key", ".events/2022-03-08/.*")
-        assert at_least_one_matches_key(objects['Contents'], "Key", ".events/2022-03-09/.*")
+        assert at_least_one_matches_key(objects['Contents'], "Key", ".events/2022-03-08/.*")
+        assert at_least_one_matches_key(objects['Contents'], "Key", ".events/2022-04-08/.*")
         assert at_least_one_matches_key(objects['Contents'], "Key", ".clusters/[0-9]{4}-[0-9]{2}-[0-9]{2}/.*")
         assert at_least_one_matches_key(objects['Contents'], "Key", ".component_versions/[0-9]{4}-[0-9]{2}-[0-9]{2}/.*")
         assert at_least_one_matches_key(objects['Contents'], "Key", ".infra_envs/[0-9]{4}-[0-9]{2}-[0-9]{2}/.*")


### PR DESCRIPTION
At the moment we have the issue that we might stick duplicate data in the indices, as the current system relies on conflicts when inserting already downloaded data.
This change avoids that by just inserting events by date instead of time of indexing