### PR TITLE
fetch data for streams that are unpartitioned but they actually have an offset

### DIFF
--- a/assisted-events-scrape/ccx_export/export_to_s3.py
+++ b/assisted-events-scrape/ccx_export/export_to_s3.py
@@ -2,6 +2,7 @@ from config import EventExportConfig, EventStoreConfig
 from clients import create_es_client_from_env
 from events import EventStream, EventsExporter
 from storage import DateOffsetOptions, DateOffsetRepository, ObjectStorageWriter
+from utils import log
 
 
 def export_events():
@@ -43,4 +44,5 @@ def export_events():
 
     exporter = EventsExporter(cfg, es_client, writer, offset_repo)
     for stream in event_streams:
+        log.info("Exporting stream %s", stream)
         exporter.export_stream(stream)


### PR DESCRIPTION
This PR fixes a bug where we do not export unpartitioned data if we already exported it before (thus have an offset).
In the specific case, we are not exporting `component_versions` as data is unpartitioned (no cluster_id) and it has been exported before.

This bug has been introduced when we have changed the way we export data, only one version is missing for now.
Once fixed, it should be exported automatically.