### PR TITLE
add logging to see what is causing anonymizer to break

### DIFF
--- a/assisted-events-scrape/utils/anonymizer.py
+++ b/assisted-events-scrape/utils/anonymizer.py
@@ -1,4 +1,5 @@
 import fnv
+from .logger import log
 
 
 class Anonymizer:
@@ -13,12 +14,16 @@ class Anonymizer:
     @classmethod
     def _hash_user_name(cls, resource: dict):
         """mask user name with unique generated FNV-1a 128 bit id"""
+
         if "user_name" not in resource:
             return
 
-        user_name = resource.pop("user_name")
+        try:
+            user_name = resource.pop("user_name")
+        except KeyError:
+            log.warning(f"Key error while parsing user_name: {type(resource)} {resource}")
+            return
 
-        # empty username
         if not user_name:
             resource["user_id"] = None
         else:


### PR DESCRIPTION
Not sure how this can happen but we got some of those errors:
![image](https://user-images.githubusercontent.com/18526422/200631696-8019dd9e-5542-40f0-bca0-05c54a5bc57c.png)

Adding None as default value should get rid of KeyError