### PR TITLE
ignore dep upgrade for opensearch and kubernetes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,9 @@ updates:
       python-dependencies:
         patterns:
           - "*"
+    ignore:
+      - opensearch-py
+      - kubernetes
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
This PR ignoes upgrades to opensearch and kubernetes packages, as we might inadvertedly upgrade it too far and break compatibility.