### PR TITLE
fix ccx export

### DIFF
--- a/assisted-events-scrape/events/events_exporter.py
+++ b/assisted-events-scrape/events/events_exporter.py
@@ -95,7 +95,7 @@ class EventsExporter:
         must = []
         if offset:
             offset_range = {"range": {stream.options.order_key: {"gt": offset}}}
-            must = [offset_range]
+            must.append(offset_range)
 
         if stream.options.partition_key:
             partition_filter = {"term": {stream.options.partition_key: partition}}


### PR DESCRIPTION
CCX export is breaking because too many partitions are retrieved.

Although this repo is deprecated we need to fix it so exportable data won't accumulate, we'll later implement this export in the kafka based pipeline