### PR TITLE
remove dataclasses as they are built-in from python 3.7

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
 ENV VIRTUAL_ENV=/opt/venv\
     PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 assisted-service-client~=2.1.0
 boto3~=1.22.6
-dataclasses~=0.8
 dpath~=2.0.6
 fnv~=0.2.0
 kubernetes~=18.20.0


### PR DESCRIPTION
this dependency wouldn't build the image, we should probably build the production image as part of tests.
The solution is to remove it as it's a backport of a feature from python 3.7, and ubi image upgrade upgraded base python version